### PR TITLE
Second parameter of requests.post() method should be the data payload...

### DIFF
--- a/assess.py
+++ b/assess.py
@@ -7,7 +7,7 @@ import string
 def assess(data):
     print("Processing", data)
     try:
-        r = requests.post(data["sts"], None, {
+        r = requests.post(data["sts"], {
             "client_id": data["client_id"],
             "client_secret": data["client_secret"],
             "audience": data["audience"],


### PR DESCRIPTION
if we wish to send the payload as x-www-form-urlencoded (as defined in https://tools.ietf.org/html/rfc6749. I assume this is also applicable to OIDC) See http://docs.python-requests.org/en/master/api/#requests.post